### PR TITLE
Environment Improvements

### DIFF
--- a/datapusher-plus/0.10.1/Dockerfile
+++ b/datapusher-plus/0.10.1/Dockerfile
@@ -82,8 +82,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY .env ${SRC_DIR}/datapusher/.env
-ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
+COPY .env ${SRC_DIR}/datapusher-plus/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher-plus/datapusher/.env
 
 
 

--- a/datapusher-plus/0.10.1/Dockerfile
+++ b/datapusher-plus/0.10.1/Dockerfile
@@ -82,8 +82,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY ./example.env ${CFG_DIR}/.env
-ENV JOB_CONFIG=${CFG_DIR}/.env
+COPY .env ${SRC_DIR}/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
 
 
 

--- a/datapusher-plus/0.11.0/Dockerfile
+++ b/datapusher-plus/0.11.0/Dockerfile
@@ -85,8 +85,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY ./example.env ${CFG_DIR}/.env
-ENV JOB_CONFIG=${CFG_DIR}/.env
+COPY .env ${SRC_DIR}/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
 
 
 

--- a/datapusher-plus/0.11.0/Dockerfile
+++ b/datapusher-plus/0.11.0/Dockerfile
@@ -85,8 +85,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY .env ${SRC_DIR}/datapusher/.env
-ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
+COPY .env ${SRC_DIR}/datapusher-plus/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher-plus/datapusher/.env
 
 
 

--- a/datapusher-plus/0.13.2/Dockerfile
+++ b/datapusher-plus/0.13.2/Dockerfile
@@ -84,8 +84,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY ./example.env ${CFG_DIR}/.env
-ENV JOB_CONFIG=${CFG_DIR}/.env
+COPY .env ${SRC_DIR}/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
 
 
 

--- a/datapusher-plus/0.13.2/Dockerfile
+++ b/datapusher-plus/0.13.2/Dockerfile
@@ -84,8 +84,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY .env ${SRC_DIR}/datapusher/.env
-ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
+COPY .env ${SRC_DIR}/datapusher-plus/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher-plus/datapusher/.env
 
 
 

--- a/datapusher-plus/0.14.1/Dockerfile
+++ b/datapusher-plus/0.14.1/Dockerfile
@@ -84,8 +84,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY ./example.env ${CFG_DIR}/.env
-ENV JOB_CONFIG=${CFG_DIR}/.env
+COPY .env ${SRC_DIR}/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
 
 
 

--- a/datapusher-plus/0.14.1/Dockerfile
+++ b/datapusher-plus/0.14.1/Dockerfile
@@ -84,8 +84,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY .env ${SRC_DIR}/datapusher/.env
-ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
+COPY .env ${SRC_DIR}/datapusher-plus/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher-plus/datapusher/.env
 
 
 

--- a/datapusher-plus/0.15.0/Dockerfile
+++ b/datapusher-plus/0.15.0/Dockerfile
@@ -83,9 +83,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY .env ${SRC_DIR}/datapusher/.env
-ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
-
+COPY .env ${SRC_DIR}/datapusher-plus/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher-plus/datapusher/.env
 
 
 

--- a/datapusher-plus/0.15.0/Dockerfile
+++ b/datapusher-plus/0.15.0/Dockerfile
@@ -83,8 +83,8 @@ RUN cd ${SRC_DIR}/datapusher-plus && \
 
 #SETUP CONFIG/SETTINGS.PY
 RUN mkdir -p ${CFG_DIR}
-COPY ./example.env ${CFG_DIR}/.env
-ENV JOB_CONFIG=${CFG_DIR}/.env
+COPY .env ${SRC_DIR}/datapusher/.env
+ENV JOB_CONFIG=${SRC_DIR}/datapusher/.env
 
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,10 +9,14 @@ services:
     build:
       context: ./datapusher-plus/0.15.0/
       dockerfile: Dockerfile
-
+    networks:
+      - ckan-docker_default
     ports:
       - "8800:8800"
     network_mode: "host"
-    environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql://datapusher_jobs:<YOUR_PASSWORD>@localhost/datapusher_jobs
-      - WRITE_ENGINE_URL=postgresql://datapusher:<YOUR_PASSWORD>@localhost/datastore_default
+    restart: unless-stopped
+
+networks:
+  ckan-docker_default:
+    external: true
+


### PR DESCRIPTION
Since at least 0.10.0, datapusher-plus has expected its environment file in the directory it launches from, not /etc/ckan/datapusher. This patch respects that behaviour. docker-compose.yml is also modified to use the same network name that a Docker-ized but otherwise unmodified CKAN would have.